### PR TITLE
fix the issue for Seurat object

### DIFF
--- a/R/internals.R
+++ b/R/internals.R
@@ -18,13 +18,20 @@
    return(res)
 }
 
-.split.by.feature <- function(p, ncol){
+.split.by.feature <- function(p, ncol, joint = FALSE){
    rlang::check_installed('aplot', 'for split ggplot object by features.')
    p <- p$data |> dplyr::group_split(.data$features) |>
            lapply(function(i){
-              p$data <-i
+              p$data <- i
               return(p)
             })
+
+   indx <- length(p)
+   
+   if (joint){
+      p[[indx]] <- p[[indx]] + ggplot2::labs(colour = 'joint_density')
+   }
+   
    p <- aplot::plot_list(gglist = p, ncol = ncol)
    return(p)
 }

--- a/R/sc-dim.R
+++ b/R/sc-dim.R
@@ -179,14 +179,14 @@ get_dim_data <- function(object, features = NULL,
             xx <- cbind(sp.coords, xx, tmp)
         }else if (!is.null(reduced.dat) && !density){
             xx <- cbind(reduced.dat, xx, tmp)
+        }else{
+            xx <- cbind(xx, tmp)
         }
     }else{
         if (!is.null(reduced.dat)){
             xx <- cbind(reduced.dat, xx)
         }
     }
-    #SeuratObject::FetchData(object, vars = c(dims, "ident", 
-    #    features), cells = cells, slot = slot)
 
     return(xx)
 }

--- a/R/sc-dim.R
+++ b/R/sc-dim.R
@@ -179,7 +179,9 @@ get_dim_data <- function(object, features = NULL,
             xx <- cbind(sp.coords, xx, tmp)
         }else if (!is.null(reduced.dat) && !density){
             xx <- cbind(reduced.dat, xx, tmp)
-        }
+        }else{
+            xx <- cbind(xx, tmp)
+	}
     }else{
         if (!is.null(reduced.dat)){
             xx <- cbind(reduced.dat, xx)

--- a/R/sc-spatial.R
+++ b/R/sc-spatial.R
@@ -116,7 +116,8 @@ setMethod("sc_spatial", 'Seurat',
         d <- tidyr::pivot_longer(
                d, 
                indx.f, 
-               names_to = 'features'
+               names_to = 'features',
+               values_to = valnm
              )
         d$features <- factor(d$features, levels=features)
         default_mapping <- modifyList(default_mapping, aes_string(color = valnm))

--- a/R/sc-spatial.R
+++ b/R/sc-spatial.R
@@ -98,14 +98,13 @@ setMethod("sc_spatial", 'Seurat',
     if (density){
        valnm <- 'density'
        if (joint){
-           valnm <- "joint density"
+           #valnm <- "joint_density"
            nm.f <- nm.f + 1
        }
     }else{
        valnm <- slot
+       d <- cbind(coord, d)
     }
-
-    d <- cbind(coord, d)
 
     default_mapping <- aes_string(x = colnames(coord)[2], y = colnames(coord)[1])
 
@@ -161,7 +160,8 @@ setMethod("sc_spatial", 'Seurat',
     }     
 
     if (!common.legend && length(features) > 1){
-        p <- .split.by.feature(p, ncol)
+        ncol <- min(length(features), ncol)
+        p <- .split.by.feature(p, ncol, joint)
     }    
     return(p)    
 })
@@ -216,7 +216,7 @@ setMethod('sc_spatial', 'SingleCellExperiment', function(object,
         if (density){
            valnm <- 'density'
            if (joint){
-               valnm <- "joint density"
+               #valnm <- "joint_density"
                nm.f <- nm.f + 1
            }
         }else{
@@ -273,7 +273,8 @@ setMethod('sc_spatial', 'SingleCellExperiment', function(object,
     }
 
     if (!common.legend && length(features) > 1){
-        p <- .split.by.feature(p, ncol)
+        ncol <- min(length(features), ncol)
+        p <- .split.by.feature(p, ncol, joint)
     }
     return(p)
 })


### PR DESCRIPTION
+ fixed the issues for `Seurat` object
      the `rmd` file of `docs` runs well.
      and the `make all` no error.

```
> brain |> sc_spatial(features=c("Hpca", "Ttr"), image.mirror.axis='v') -> f1
> brain |> sc_spatial(features=c("Hpca", "Ttr"), image.mirror.axis='v', density=T) -> f2
> f1 / f2
```
![image](https://github.com/YuLab-SMU/ggsc/assets/17870644/ff6dfc28-1807-4097-aa1c-38f9c7fbe2e1)

```
> spe |> sc_spatial(features=c(2000, 3000), image.rotate.degree=-90) -> p1
> spe |> sc_spatial(features=c(2000, 3000), image.rotate.degree=-90, density=T) -> p2
```
![image](https://github.com/YuLab-SMU/ggsc/assets/17870644/6246bcec-a292-4e2f-a17f-35e9afd60d19)

+ adjust the legend title when `joint=T`

```
> spe |> sc_spatial(features=c(2000, 3000), image.rotate.degree=-90, density=T, joint=T) -> p3
> spe |> sc_spatial(features=c(2000, 3000), image.rotate.degree=-90, density=T, joint=T, common.legend=F) -> p4
```
![image](https://github.com/YuLab-SMU/ggsc/assets/17870644/18dc218b-cbb0-4dae-824a-fb9bd045c21d)

```
> brain |> sc_spatial(features=c("Hpca", "Ttr"), image.mirror.axis='v', density=T, joint=T) -> f3
> brain |> sc_spatial(features=c("Hpca", "Ttr"), image.mirror.axis='v', density=T, joint=T, common.legend=F) -> f4
```
![image](https://github.com/YuLab-SMU/ggsc/assets/17870644/d77cd6ad-46ac-46d2-ac0f-091bdf345da6)

