### PR TITLE
add the meta.data of cell for Seurat

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -8,3 +8,4 @@ gh-pages
 ^\.Rproj\.user$
 ^\.Rproj$
 docs
+^\.github

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,7 +14,7 @@ Authors@R: c(
        ),
        person("Noriaki", "Sato", 
               email = "nori@hgc.jp", 
-              role = "cbt")
+              role = "ctb")
   )
 Description: Useful functions to visualize single cell and spatial 
   data. It supports visualizing 'Seurat', 'SingleCellExperiment' and 'SpatialExperiment' objects through grammar of graphics syntax implemented in 'ggplot2'.

--- a/R/sc-dim.R
+++ b/R/sc-dim.R
@@ -161,7 +161,8 @@ get_dim_data <- function(object, features = NULL,
     if (is.null(cells)) {
         cells <- colnames(object)
     }
-    xx <- data.frame(ident=SeuratObject::Idents(object)[cells])
+    #xx <- data.frame(ident=SeuratObject::Idents(object)[cells])
+    xx <- cbind(data.frame(ident = SeuratObject::Idents(object)[cells]), object@meta.data[cells,,drop=FALSE])
     
     if (!is.null(dims)) {
         if (is.null(reduction)) {

--- a/R/sc-dot.R
+++ b/R/sc-dot.R
@@ -72,7 +72,10 @@ setMethod("sc_dot", 'Seurat', function(object, features,
         features <- unlist(features)
     }
     d <- get_dim_data(object, dims=NULL, features=features, slot=slot)
-    d <- tidyr::pivot_longer(d, 2:ncol(d), names_to = "features")
+    
+    indx.f <- seq(ncol(d) - length(features) + 1, ncol(d))
+    d <- tidyr::pivot_longer(d, cols=indx.f, names_to = "features")
+
     d$features <- factor(d$features, levels = features)        
 
     if (!is.null(.fun)) {

--- a/R/sc-spatial.R
+++ b/R/sc-spatial.R
@@ -138,7 +138,7 @@ setMethod("sc_spatial", 'Seurat',
         p <- p + img.annot
     }
 
-    if (!remove.point && !(is.null(features) || missing(features))){
+    if ((!remove.point && (!is.null(features) || (any(names(mapping) %in% c('color', 'colour')) && is.null(features))))){
         p <- p + sc_geom_point(pointsize = point.size, ...)
     }else{
         p <- p + geom_blank()
@@ -251,7 +251,7 @@ setMethod('sc_spatial', 'SingleCellExperiment', function(object,
         p <- p + img.annot
     }
 
-    if (!remove.point && !(is.null(features) || missing(features))){
+    if ((!remove.point && (!is.null(features) || (any(names(mapping) %in% c('color', 'colour')) && is.null(features))))){
         p <- p + sc_geom_point(pointsize = point.size, ...) 
     }else{
         p <- p + geom_blank()

--- a/R/sc-violin.R
+++ b/R/sc-violin.R
@@ -49,7 +49,8 @@ setMethod("sc_violin", 'Seurat', function(object, features,
                     cells=NULL, slot = "data", .fun = NULL, 
                     mapping = NULL, ncol=3, ...) {
     d <- get_dim_data(object, dims=NULL, features=features)
-    d <- tidyr::pivot_longer(d, 2:ncol(d), names_to = "features")
+    indx.f <- seq(ncol(d) - length(features) + 1, ncol(d))
+    d <- tidyr::pivot_longer(d, cols=indx.f, names_to = "features") 
     d$features <- factor(d$features, levels = features)
     if (!is.null(.fun)) {
         d <- .fun(d)

--- a/man/ggsc-package.Rd
+++ b/man/ggsc-package.Rd
@@ -4,14 +4,15 @@
 \name{ggsc-package}
 \alias{ggsc}
 \alias{ggsc-package}
-\title{ggsc: Visualizing Single Cell Data}
+\title{ggsc: Visualizing Single Cell and Spatial Transcriptomics}
 \description{
-Useful functions to visualize single cell and spatial data. It supports both 'SingleCellExperiment' and 'Seurat' objects. It also supports visualizing the data using grammar of graphics implemented in 'ggplot2'.
+Useful functions to visualize single cell and spatial data. It supports visualizing 'Seurat', 'SingleCellExperiment' and 'SpatialExperiment' objects through grammar of graphics syntax implemented in 'ggplot2'.
 }
 \seealso{
 Useful links:
 \itemize{
-  \item \url{https://github.com/YuLab-SMU/ggsc}
+  \item \url{https://github.com/YuLab-SMU/ggsc (devel)}
+  \item \url{https://yulab-smu.top/ggsc/ (docs)}
   \item Report bugs at \url{https://github.com/YuLab-SMU/ggsc/issues}
 }
 
@@ -22,6 +23,11 @@ Useful links:
 Authors:
 \itemize{
   \item Shuangbin Xu \email{xshuangbin@163.com} (\href{https://orcid.org/0000-0003-3513-5362}{ORCID})
+}
+
+Other contributors:
+\itemize{
+  \item Noriaki Sato \email{nori@hgc.jp} [contributor]
 }
 
 }


### PR DESCRIPTION
considering the meta.data of cell for `Seurat` object in `get_dim_data`

related #16 

```
> library(ggsc)
> pbmc.seut <- readRDS('./pbmc_seurat.rds')
> p <- pbmc.seut |> sc_dim()
> p$data |> head()
                     UMAP_1    UMAP_2        ident orig.ident nCount_RNA
AAACATACAACCAC-1   3.325538 -4.101189  Naive CD4 T     pbmc3k       2419
AAACATTGAGCTAC-1   4.449747 11.148801            B     pbmc3k       4903
AAACATTGATCAGC-1   6.016574 -6.904137 Memory CD4 T     pbmc3k       3147
AAACCGTGCTTCCG-1 -10.999634  4.242199 FCGR3A+ Mono     pbmc3k       2639
AAACCGTGTATGCG-1   5.014720  1.765654           NK     pbmc3k        980
AAACGCACTGGTAC-1   2.496269 -6.072399 Memory CD4 T     pbmc3k       2163
                 nFeature_RNA RNA_snn_res.0.5 seurat_clusters
AAACATACAACCAC-1          779               0               0
AAACATTGAGCTAC-1         1352               3               3
AAACATTGATCAGC-1         1129               2               2
AAACCGTGCTTCCG-1          960               5               5
AAACCGTGTATGCG-1          521               6               6
AAACGCACTGGTAC-1          781               2               2
> p2 <- pbmc.seut |> sc_dim(mapping=aes(color=seurat_clusters))
> p + p2
```
![image](https://github.com/YuLab-SMU/ggsc/assets/17870644/099898b3-9681-49be-a491-e064ee597570)
