### PR TITLE
fix the function of features parameter

### DIFF
--- a/R/plot-methods.R
+++ b/R/plot-methods.R
@@ -84,7 +84,11 @@ plot_lisa_feature <- function(spe,
         }
     }else if(inherits(lisa.res, 'SimpleList') || inherits(lisa.res, "list")){
         names(lisa.res) <- gsub("_", " ", names(lisa.res))
-        features <- names(lisa.res)
+        if(is.null(features)){
+          features <- names(lisa.res)
+        }else{
+          lisa.res <- lisa.res[features]
+        }
     }
     rownames(spe) <- gsub("_", " ", rownames(spe))
     if (is.null(reduction)){


### PR DESCRIPTION
In the former function, adding values to features can not show the specific item. Instead function will show all result.
```
p <- plot_lisa_feature(spe = SVP::gsvaExp(spe1,'LISA'),
                                      lisa.res = lisa,
                                      features ="CD6 T cells",
                                      assay.type='Gi',
                                      geom = geom_bg,
                                      pointsize=1,
                                      common.legend = TRUE,
                                      ncol = 4)
```
This pr is to fix this bug, after fixing, function will return specific result of feature.